### PR TITLE
[Bugfix] Use correct vm.$set signature

### DIFF
--- a/vue-async-data.js
+++ b/vue-async-data.js
@@ -28,7 +28,7 @@
           var resolve = function (data) {
             if (data) {
               for (var key in data) {
-                self.$set(key, data[key])
+                self.$set(self, key, data[key])
               }
             }
             self.$loadingAsyncData = false


### PR DESCRIPTION
`vm.$set` is only an alias to `Vue.set`,
which means that `self` is not `this`, it has to be passed as first argument.